### PR TITLE
Fix comparison with TZ aware datetime in TimeLimit rule

### DIFF
--- a/imapautofiler/tests/test_rules.py
+++ b/imapautofiler/tests/test_rules.py
@@ -499,3 +499,7 @@ class TestTimeLimit(base.TestCase):
     def test_time_limit_current(self):
         r = rules.TimeLimit(self.get_def(), {})
         self.assertEqual(r.check(self.recent_msg), 0)
+
+    def test_time_limit_expired_without_offset(self):
+        r = rules.TimeLimit(self.get_def(), {})
+        self.assertTrue(r.check(self.without_offset_msg))


### PR DESCRIPTION
Depending on the string parsed, `parsedate_to_datetime` gives either a
timezone aware datetime or a timezone naive datetime.

To be able to compare them safely with the current date, this commit
makes sure that all datetimes used throughout the application are
TZ aware.