### PR TITLE
Make sure the timezone matches the message timezone

### DIFF
--- a/imapautofiler/rules.py
+++ b/imapautofiler/rules.py
@@ -268,8 +268,9 @@ class TimeLimit(Rule):
 
     def check(self, message):
         date = parsedate_to_datetime(i18n.get_header_value(message, 'date'))
+        msg_tz = date.tzinfo
         if self._age:
-            time_limit = datetime.now() - timedelta(days=self._age)
+            time_limit = datetime.now(tz=msg_tz) - timedelta(days=self._age)
             if date <= time_limit:
                 return True
             else:


### PR DESCRIPTION
On newer version of python you can't do <= comparisons
on datetime objects without timezone data and those
with timezone data.

This change sets datetime.now to use the message timezone.

You get an error like the following:

*** TypeError: can't compare offset-naive and offset-aware datetimes.
[A