### PR TITLE
Fix comparison with TZ aware datetime in TimeLimit rule

### DIFF
--- a/imapautofiler/tests/base.py
+++ b/imapautofiler/tests/base.py
@@ -19,6 +19,7 @@ import logging
 import unittest
 
 import fixtures
+from datetime import datetime, timezone, timedelta
 
 
 def construct_message(headers):
@@ -31,9 +32,9 @@ def construct_message(headers):
     return msg.as_string()
 
 
-date = format_datetime(datetime.datetime.now())
+date = format_datetime(datetime.now(timezone.utc))
 past_date = format_datetime(
-    datetime.datetime.now() - datetime.timedelta(days=90)
+    datetime.now(timezone.utc) - timedelta(days=90)
 )
 MESSAGE = {
     'From': 'Sender Name <sender@example.com>',
@@ -44,7 +45,7 @@ MESSAGE = {
     'Mime-Version': r'1.0 (Mac OS X Mail 9.2 \(3112\))',
     'X-Smtp-Server': 'AE35BF63-D70A-4AB0-9FAA-3F18EB9802A9',
     'Subject': 'Re: reply to previous message',
-    'Date': '{}'.format(past_date),
+    'Date': past_date,
     'X-Universally-Unique-Identifier': 'CC844EE1-C406-4ABA-9DA5-685759BBC15A',
     'References': '<33509d2c-e2a7-48c0-8bf3-73b4ba352b2f@example.com>',
     'To': 'recipient1@example.com',
@@ -62,7 +63,12 @@ I18N_MESSAGE.update({
 
 RECENT_MESSAGE = MESSAGE.copy()
 RECENT_MESSAGE.update({
-    'Date': '{}'.format(date),
+    'Date': date,
+})
+
+WITHOUT_OFFSET_MESSAGE = MESSAGE.copy()
+WITHOUT_OFFSET_MESSAGE.update({
+    'Date': 'Thu, 07 Sep 2000 20:57:30 -0000',
 })
 
 
@@ -70,6 +76,7 @@ class TestCase(unittest.TestCase):
     _msg = None
     _recent_msg = None
     _i18n_msg = None
+    _without_offset_msg = None
 
     def setUp(self):
         super().setUp()
@@ -107,6 +114,14 @@ class TestCase(unittest.TestCase):
                 construct_message(RECENT_MESSAGE)
             )
         return self._recent_msg
+
+    @property
+    def without_offset_msg(self):
+        if self._without_offset_msg is None:
+            self._without_offset_msg = email.parser.Parser().parsestr(
+                construct_message(WITHOUT_OFFSET_MESSAGE)
+            )
+        return self._without_offset_msg
 
 
 def pytest_generate_tests(metafunc):

--- a/imapautofiler/tests/test_rules.py
+++ b/imapautofiler/tests/test_rules.py
@@ -507,3 +507,7 @@ class TestTimeLimit(base.TestCase):
     def test_time_limit_current(self):
         r = rules.TimeLimit(self.get_def(), {})
         self.assertEqual(r.check(self.recent_msg), 0)
+
+    def test_time_limit_expired_without_offset(self):
+        r = rules.TimeLimit(self.get_def(), {})
+        self.assertTrue(r.check(self.without_offset_msg))


### PR DESCRIPTION
Depending on the string parsed, `parsedate_to_datetime` gives either a
timezone aware datetime or a timezone naive datetime.

To be able to compare them safely with the current date, this commit
makes sure that all datetimes used throughout the application are
TZ aware.