### PR TITLE
add secrets module to API docs

### DIFF
--- a/doc/source/api/autoindex.rst
+++ b/doc/source/api/autoindex.rst
@@ -8,3 +8,4 @@
    imapautofiler.i18n.rst
    imapautofiler.lookup.rst
    imapautofiler.rules.rst
+   imapautofiler.secrets.rst

--- a/doc/source/api/imapautofiler.secrets.rst
+++ b/doc/source/api/imapautofiler.secrets.rst
@@ -1,0 +1,7 @@
+The :mod:`imapautofiler.secrets` Module
+=======================================
+
+.. automodule:: imapautofiler.secrets
+  :members:
+  :undoc-members:
+  :show-inheritance:


### PR DESCRIPTION
Check in the auto-generated file for adding imapautofiler.secrets to
the API documentation. If we do not check this file in, the set of API
documentation published on readthedocs.org will not include it because
the extension to generate the files does not run there.