### PR TITLE
move CONTRIBUTING.rst to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,6 @@ should use the same license.
 
 When reporting a bug, please specify the version of imapautofiler you
 are using.
+
+See https://imapautofiler.readthedocs.io/en/latest/contributing.html
+for more details about code organization.


### PR DESCRIPTION
The contribution instructions aren't showing up, so rename the file to
see if that fixes it.