### PR TITLE
fix contributing docs

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -2,7 +2,18 @@
  Contributing
 ==============
 
-.. include:: ../../CONTRIBUTING.rst
+The Basics
+==========
+
+The source code and bug tracker for imapautofiler are `hosted on
+github <https://github.com/imapautofiler/imapautofiler>`__.
+
+The source code is released under the Apache 2.0 license. All patches
+should use the same license.
+
+When reporting a bug, please specify the version of imapautofiler you
+are using.
+
 
 Message handling rules
 ======================


### PR DESCRIPTION
Renaming the contributing file broke the documentation build.