### PR TITLE
use the correct default ssl context

### DIFF
--- a/imapautofiler/client.py
+++ b/imapautofiler/client.py
@@ -19,7 +19,6 @@ import email.parser
 import logging
 import mailbox
 import os
-import ssl
 
 import imapclient
 
@@ -121,11 +120,9 @@ class IMAPClient(Client):
         super().__init__(cfg)
 
         # Use default client behavior if ca_file not provided.
-        context = None
+        context = imapclient.create_default_context()
         if 'ca_file' in cfg['server']:
-            context = ssl.create_default_context(
-                cafile=cfg['server']['ca_file']
-            )
+            context.cafile = cfg['server']['ca_file']
 
         self._conn = imapclient.IMAPClient(
             cfg['server']['hostname'],


### PR DESCRIPTION
Follow the instructions at
https://imapclient.readthedocs.io/en/1.0.2/index.html#tls-ssl for
creating the SSL context to avoid exceptions related to closing the
socket, such as https://github.com/mjs/imapclient/issues/290

Addresses #54