### PR TITLE
start moving from travis to github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+name: Check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environment:
+          - docs
+          - pep8
+          - pkglint
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      - name: Run
+        run: tox -e ${{ matrix.tox-environment }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      - name: Run tests
+        run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distribute = False
-envlist = pep8,py36,py37,py38
+envlist = pep8,py36,py37,py38,py39,docs,pkglint
 
 [testenv]
 deps = .[test]

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,10 @@ deps =
   .[test]
 commands =
     {toxinidir}/tools/maildir_test_data.py {posargs}
+
+[testenv:pkglint]
+deps=
+    twine
+commands=
+    python setup.py sdist
+    twine check dist/*.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = pep8,py36,py37,py38
 deps = .[test]
 setenv = VIRTUAL_ENV={envdir}
 commands =
-    {toxinidir}/tools/travis.sh '{posargs}'
+    pytest --cov=imapautofiler --cov-report term-missing --cov-config {toxinidir}/.coveragerc
 
 [testenv:pep8]
 basepython = python3.7
@@ -21,7 +21,7 @@ exclude = .tox,dist,doc,*.egg,build
 deps =
   -r doc/requirements.txt
 commands =
-    python setup.py build_sphinx
+    python -m sphinx.cmd.build -E -W -v -T doc/source doc/build
 
 [testenv:testdata]
 deps =


### PR DESCRIPTION
Travis CI has placed limits on open source project test jobs. Moving
to github actions will avoid being blocked by those limits.