### PR TITLE
Implement 'flag' action

### DIFF
--- a/doc/source/configuring.rst
+++ b/doc/source/configuring.rst
@@ -411,6 +411,8 @@ regular expression ``notify-.*@disqus.net`` to the trash mailbox.
      action:
        name: trash
 
+.. _config-delete-action:
+
 Delete Action
 -------------
 
@@ -427,6 +429,65 @@ regular expression ``notify-.*@disqus.net``.
          regex: "notify-.*@disqus.net"
      action:
        name: delete
+
+Flag Action
+-----------
+
+The ``flag`` action can set the flags of a mesage or add and remove flags.
+Message flags are an IMAP feature, which allows to mark messages as seen (i.e.
+read), answered, flagged (i.e. urgent/special attention) or as a draft or
+deleted or to add keywords to it. Flags are not supported by Maildir mailboxes
+and the ``flag`` action has no effect, if used in this context.
+
+IMAP defines a set of *system flags*, which start with a backslash. You can use
+one of the following constants to refer to these flags::
+
+    ANSWERED = '\Answered'
+    DELETED = '\Deleted'
+    DRAFT = '\Draft'
+    FLAGGED = '\Flagged'
+    SEEN = '\Seen'
+
+IMAP servers may support other system flags or keywords (i.e. flags not starting
+with a backslash). See `RFC-2060`_ for more information on flags.
+
+The action can replace the message's flags using the ``set`` entry in the action
+settings. The entry value can either be a single flag or a list of flags.
+
+The following example would set the ``\Flagged`` and ``\Seen`` flags on the
+message and remove all other flags.:
+
+.. code-block:: yaml
+
+    action:
+      name: flag
+      set:
+      - FLAGGED
+      - SEEN
+
+Alternatively, flags can be added using the ``add`` entry or removed using the
+``remove`` entry. The following example would add the ``\Flagged`` flag and
+remove the ``\Seen`` flag from the message but leave all other existing flags
+in place:
+
+.. code-block:: yaml
+
+    action:
+        name: flag
+        add: FLAGGED
+        remove: SEEN
+
+It is an error to use a ``set`` entry together with an ``add`` or a ``remove``
+entry in the same ``flag`` action. If both ``add`` and ``remove`` entries are
+present, the latter takes precedence, i.e. if the same flag is present in
+both entry values, it is removed from the message.
+
+.. warning::
+    Setting or adding the ``DELETED`` flag on a message in an IMAP mailbox
+    is equivalent to the :ref:`config-delete-action`, i.e. the message is
+    permanently removed when the mailbox is expunged.
+
+.. _rfc-2060: https://tools.ietf.org/html/rfc2060#section-2.3.2
 
 Complete example configuration file
 ===================================

--- a/imapautofiler/actions.py
+++ b/imapautofiler/actions.py
@@ -299,6 +299,115 @@ class Delete(Action):
         )
 
 
+class Flag(Action):
+    r"""Set, add or remove one or more message flags.
+
+    The action is indicated with the name ``flag``.
+
+    The action expects either a "set" or an "add" and / or a "remove" entry,
+    which specify the flag(s) to set or add and / or remove. The entry value
+    can either be a single flag or a list of flags. IMAP defines several
+    *system flags*, which start with a backslash, e.g. ``\Seen``. You can use
+    one of the following constants to refer to these system flags::
+
+        ANSWERED = r'\Answered'
+        DELETED = r'\Deleted'
+        DRAFT = r'\Draft'
+        FLAGGED = r'\Flagged'
+        SEEN = r'\Seen'
+
+    IMAP servers may support other system flags or keywords (i.e. flags not
+    starting with a backslash). See RFC-2060 for more information on flags.
+
+    Examples::
+
+
+        action:
+          name: flag
+          set:
+          - FLAGGED
+          - SEEN
+
+    This would set the ``\Flagged`` and ``\Seen`` flags on the message and
+    remove all other flags.
+
+    And:
+
+        action:
+            name: flag
+            add: FLAGGED
+            remove: SEEN
+
+    This would add the ``\Flagged`` flag and remove the ``\Seen`` flag from
+    the message but leave all other existing flags in place.
+
+    """
+
+    NAME = 'flag'
+    _log = logging.getLogger(NAME)
+    _system_flags = {
+        'ANSWERED': r'\Answered',
+        'DELETED': r'\Deleted',
+        'DRAFT': r'\Draft',
+        'FLAGGED': r'\Flagged',
+        'SEEN': r'\Seen',
+    }
+
+    def __init__(self, action_data, cfg):
+        super().__init__(action_data, cfg)
+        self._set = self._get_flags('set')
+        self._add = self._get_flags('add')
+        self._remove = self._get_flags('remove')
+
+        if self._set and (self._add or self._remove):
+            raise ValueError(
+                'Action data must have either a "set" entry or an "add" and / '
+                'or a "remove" entry but not both for action {}'.format(
+                    action_data)
+            )
+
+        if not self._set and not (self._add or self._remove):
+            raise ValueError(
+                'Action data must have a "set", "add" or "remove" entry for '
+                'action {}'.format(
+                    action_data)
+            )
+
+    def _get_flags(self, kind):
+        flags = self._data.get(kind, [])
+
+        if not isinstance(flags, list):
+            flags = [flags]
+
+        return {self._system_flags.get(f, str(f)) for f in flags if f}
+
+    def report(self, conn, mailbox_name, message_id, message):
+        if self._set:
+            self._log.info('%s (%s) set (%s)', message_id,
+                           i18n.get_header_value(message, 'subject'),
+                           ', '.join(self._set))
+        else:
+            if self._add:
+                self._log.info('%s (%s) add (%s)', message_id,
+                               i18n.get_header_value(message, 'subject'),
+                               ', '.join(self._add))
+            if self._remove:
+                self._log.info('%s (%s) remove (%s)', message_id,
+                               i18n.get_header_value(message, 'subject'),
+                               ', '.join(self._remove))
+
+    def invoke(self, conn, mailbox_name, message_id, message):
+        if self._set:
+            conn.set_flags(mailbox_name, message_id, message, list(self._set))
+        else:
+            if self._add:
+                conn.add_flags(mailbox_name, message_id, message,
+                               list(self._add))
+            if self._remove:
+                conn.remove_flags(mailbox_name, message_id, message,
+                                  list(self._remove))
+
+
 _lookup_table = lookup.make_lookup_table(Action, 'NAME')
 
 

--- a/imapautofiler/client.py
+++ b/imapautofiler/client.py
@@ -54,6 +54,45 @@ class Client(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def add_flags(self, src_mailbox, message_id, message, flags):
+        """Add flags to the message.
+
+        :param src_mailbox: name of the source mailbox
+        :type src_mailbox: str
+        :param message_id: ID of the message to copy
+        :type message_id: str
+        :param flags: a single mesage flag or a sequence of flags
+        :type flags: str, list[str]
+
+        """
+
+    @abc.abstractmethod
+    def remove_flags(self, src_mailbox, message_id, message, flags):
+        """Remove flags from the message.
+
+        :param src_mailbox: name of the source mailbox
+        :type src_mailbox: str
+        :param message_id: ID of the message to copy
+        :type message_id: str
+        :param flags: a single mesage flag or a sequence of flags
+        :type flags: str, list[str]
+
+        """
+
+    @abc.abstractmethod
+    def set_flags(self, src_mailbox, message_id, message, flags):
+        """Set flags on the message.
+
+        :param src_mailbox: name of the source mailbox
+        :type src_mailbox: str
+        :param message_id: ID of the message to copy
+        :type message_id: str
+        :param flags: a single mesage flag or a sequence of flags
+        :type flags: str, list[str]
+
+        """
+
+    @abc.abstractmethod
     def copy_message(self, src_mailbox, dest_mailbox, message_id, message):
         """Create a copy of the message in the destination mailbox.
 
@@ -165,6 +204,15 @@ class IMAPClient(Client):
             self._conn.create_folder(name)
             self._mbox_names.add(name)
 
+    def add_flags(self, src_mailbox, message_id, message, flags):
+        return self._conn.add_flags([message_id], flags)
+
+    def remove_flags(self, src_mailbox, message_id, message, flags):
+        return self._conn.remove_flags([message_id], flags)
+
+    def set_flags(self, src_mailbox, message_id, message, flags):
+        return self._conn.set_flags([message_id], flags)
+
     def copy_message(self, src_mailbox, dest_mailbox, message_id, message):
         self._ensure_mailbox(dest_mailbox)
         self._conn.copy([message_id], dest_mailbox)
@@ -212,6 +260,15 @@ class MaildirClient(Client):
         with self._locked(mailbox_name) as box:
             results = list(box.iteritems())
         return results
+
+    def add_flags(self, src_mailbox, message_id, message, flags):
+        pass
+
+    def remove_flags(self, src_mailbox, message_id, message, flags):
+        pass
+
+    def set_flags(self, src_mailbox, message_id, message, flags):
+        pass
 
     def copy_message(self, src_mailbox, dest_mailbox, message_id, message):
         with self._locked(dest_mailbox) as box:


### PR DESCRIPTION
Implements a new `flag` action, with which flags can be set or added and/or removed on messages.

The action expects either a "set" or an "add" and / or a "remove" entry, which specify the flag(s) to set or add and / or remove. The entry value can either be a single flag or a list of flags. An IMAP message flag is a string that usually starts with a backslash, e.g. `\Seen`. You can use one of the following constants for commonly used flags:

    ANSWERED = r'\Answered'
    DELETED = r'\Deleted'
    DRAFT = r'\Draft'
    FLAGGED = r'\Flagged'
    SEEN = r'\Seen'

Examples:

    action:
      name: flag
      set:
      - FLAGGED
      - SEEN

This would set the `\Flagged` and `\Seen` flags on the message and remove all other flags.

And:

    action:
        name: flag
        add: FLAGGED
        remove: SEEN

This would add the `\Flagged` flag and remove the `\Seen` flag from the message but leave all other existing flags in place.
