### PR TITLE
drop support for python 3.6 and 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
 

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-test_command=${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/releasenotes/notes/drop-python-3.6-77bb3180351cd195.yaml
+++ b/releasenotes/notes/drop-python-3.6-77bb3180351cd195.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    This release drops support for python 3.6 and 3.7.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,8 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Communications :: Email
 
 [files]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distribute = False
-envlist = pep8,py36,py37,py38,py39,docs,pkglint
+envlist = pep8,py37,py38,py39,docs,pkglint
 
 [testenv]
 deps = .[test]


### PR DESCRIPTION
The older versions may still work, but they are no longer being tested
on developer systems or in CI.