### PR TITLE
stop building universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,3 @@ autodoc_index_modules = True
 api_doc_dir = api
 autodoc_exclude_modules =
    imapautofiler.tests.*
-
-[wheel]
-universal = 1


### PR DESCRIPTION
The project does not support python2, so there is no point in
uploading universal wheels.