### PR TITLE
Adding search config

### DIFF
--- a/doc/source/configuring.rst
+++ b/doc/source/configuring.rst
@@ -107,6 +107,21 @@ or ``1`` (case-insensitive) will be regarded as false. The default is true).
     **Use at your own risk!** Disabling SSL/TLS connection is dangerous. You should
     preferably ask the server operator to install a proper certificate instead.
 
+Server Search
+-------------
+
+By default, the imap script will search and process ``ALL`` mail.
+It's possible to change this functionality by setting ``search`` with a value from the rfc3501_.
+The most commun values are: ``ALL``, ``UNSEEN``, ``ANSWERED``.
+
+.. _rfc3501 : https://datatracker.ietf.org/doc/html/rfc3501.html#section-6.4.4
+
+.. code-block:: yaml
+  server:
+    hostname: imap.example.com
+    username: my-user@example.com
+    search: UNSEEN
+
 Maildir Location
 ================
 

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -7,14 +7,15 @@ Run ``imapautofiler`` on the command line.
 .. code-block:: text
 
    $ imapautofiler -h
-   usage: imapautofiler [-h] [-v] [--debug] [-c CONFIG_FILE] [--list-mailboxes]
+   usage: imapautofiler [-h] [-v] [--debug] [-c CONFIG_FILE] [--list-mailboxes] [-n]
    
-   optional arguments:
+   options:
      -h, --help            show this help message and exit
      -v, --verbose         report more details about what is happening
      --debug               turn on imaplib debugging output
-     -c CONFIG_FILE, --config-file CONFIG_FILE
+     -c, --config-file CONFIG_FILE
      --list-mailboxes      instead of processing rules, print a list of mailboxes
+     -n, --dry-run         process the rules without taking any action
 
 When run with no arguments, it reads the default configuration file
 and processes the rules.

--- a/imapautofiler/client.py
+++ b/imapautofiler/client.py
@@ -244,6 +244,9 @@ class MaildirClient(Client):
         self._root = os.path.expanduser(cfg['maildir'])
         LOG.debug('maildir: %s', self._root)
         self._mbox_names = None
+        if 'search' in cfg['server']:
+            LOG.warning('Config "search" not used with a Maildir')
+            LOG.warning('All mails into the configured mailboxes will be parsed')
 
     @contextlib.contextmanager
     def _locked(self, mailbox_name):

--- a/imapautofiler/client.py
+++ b/imapautofiler/client.py
@@ -180,6 +180,7 @@ class IMAPClient(Client):
         password = secrets.get_password(cfg)
         self._conn.login(username, password)
         self._mbox_names = None
+        self.search = cfg['server'].get('search', 'ALL')
 
     def list_mailboxes(self):
         "Return a list of folder names."
@@ -190,7 +191,7 @@ class IMAPClient(Client):
 
     def mailbox_iterate(self, mailbox_name):
         self._conn.select_folder(mailbox_name)
-        msg_ids = self._conn.search(['ALL'])
+        msg_ids = self._conn.search(self.search)
         for msg_id in msg_ids:
             email_parser = email.parser.BytesFeedParser()
             response = self._conn.fetch([msg_id], ['BODY.PEEK[HEADER]'])


### PR DESCRIPTION
Here the PR for :
- a custom search for imap
- a small documentation update

The search feature is because I use this software to sort my email every 5min, so I don't need to parse all my email. In my case, only the Unread mails are enough to process.

Best regards,
Azlux